### PR TITLE
Add straightforward --input 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ clap = { version = "4.2.1", features = ["derive"] }
 rayon = "1.7.0"
 approx = "0.5.1"
 minimap2 = "0.1.17+minimap2.2.27"
+flate2 = "1.0"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ OPTIONS:
         --tailcrop      Trim N nucleotides from the end of a read [default: 0]
         --threads       Number of parallel threads to use [default: 4]
         --contam        Fasta file with reference to check potential contaminants against [default None]
-    -i, --input         Input filename if you do not what to use stdin
+    -i, --input         Input filename [default: read from stdin]
 ```
 
 EXAMPLE:  

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ OPTIONS:
 ```
 
 EXAMPLE:  
- `gunzip -c reads.fastq.gz | chopper -q 10 -l 500 | gzip > filtered_reads.fastq.gz`
- `chopper -q 10 -l 500 -i reads.fastq > filtered_reads.fastq`
+ `gunzip -c reads.fastq.gz | chopper -q 10 -l 500 | gzip > filtered_reads.fastq.gz`<br>
+ `chopper -q 10 -l 500 -i reads.fastq > filtered_reads.fastq`<br>
+ `chopper -q 10 -l 500 -i reads.fastq.gz | gzip > filtered_reads.fastfq.gz`<br>
 
 ## CITATION
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ OPTIONS:
         --tailcrop      Trim N nucleotides from the end of a read [default: 0]
         --threads       Number of parallel threads to use [default: 4]
         --contam        Fasta file with reference to check potential contaminants against [default None]
+    -i, --input <INPUT>          Input file if the user does not use stdin
 ```
 
 EXAMPLE:  
  `gunzip -c reads.fastq.gz | chopper -q 10 -l 500 | gzip > filtered_reads.fastq.gz`
+ `chopper -q 10 -l 500 -i reads.fastq > filtered_reads.fastq`
 
 ## CITATION
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ OPTIONS:
     -i, --input         Input filename [default: read from stdin]
 ```
 
-EXAMPLE:  
- `gunzip -c reads.fastq.gz | chopper -q 10 -l 500 | gzip > filtered_reads.fastq.gz`<br>
- `chopper -q 10 -l 500 -i reads.fastq > filtered_reads.fastq`<br>
- `chopper -q 10 -l 500 -i reads.fastq.gz | gzip > filtered_reads.fastfq.gz`<br>
+EXAMPLES:
+```bash
+gunzip -c reads.fastq.gz | chopper -q 10 -l 500 | gzip > filtered_reads.fastq.gz
+chopper -q 10 -l 500 -i reads.fastq > filtered_reads.fastq
+chopper -q 10 -l 500 -i reads.fastq.gz | gzip > filtered_reads.fastfq.gz
+```
 
 ## CITATION
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ OPTIONS:
         --tailcrop      Trim N nucleotides from the end of a read [default: 0]
         --threads       Number of parallel threads to use [default: 4]
         --contam        Fasta file with reference to check potential contaminants against [default None]
-    -i, --input <INPUT>          Input file if the user does not use stdin
+    -i, --input         Input filename if you do not what to use stdin
 ```
 
 EXAMPLE:  

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ struct Cli {
     #[arg(long)]
     inverse: bool,
 
-    /// Input file if the user does not use stdin
+    /// Input filename [default: read from stdin]
     #[arg(short = 'i', long = "input", value_parser)]
     input: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ struct Cli {
     #[arg(long)]
     inverse: bool,
 
-	/// Input file if the user does not use stdin
+    /// Input file if the user does not use stdin
     #[arg(short = 'i', long = "input", value_parser)]
     input: Option<String>,
 }
@@ -73,13 +73,14 @@ fn main() {
         .expect("Error: Unable to build threadpool");
 
 	match args.input {
+		/// Process file if --input exist
 		Some(ref infas) => {
         	let mut input_file = File::open(infas).unwrap();
 			
         	filter(&mut input_file, args);
 		}
 
-    	None => {
+    		None => {
     		filter(&mut io::stdin(), args);
 		}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::io::{self, Read};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::fs::File;
 
 // The arguments end up in the Cli struct
 #[derive(Parser, Debug)]
@@ -48,7 +49,12 @@ struct Cli {
     /// Output the opposite of the normal results
     #[arg(long)]
     inverse: bool,
+
+	/// Input file if the user does not use stdin
+    #[arg(short = 'i', long = "input", value_parser)]
+    input: Option<String>,
 }
+
 
 fn is_file(pathname: &str) -> Result<(), String> {
     let path = PathBuf::from(pathname);
@@ -66,7 +72,18 @@ fn main() {
         .build_global()
         .expect("Error: Unable to build threadpool");
 
-    filter(&mut io::stdin(), args);
+	match args.input {
+		Some(ref infas) => {
+        	let mut input_file = File::open(infas).unwrap();
+			
+        	filter(&mut input_file, args);
+		}
+
+    	None => {
+    		filter(&mut io::stdin(), args);
+		}
+
+	}
 }
 
 /// This function filters fastq on stdin based on quality, maxlength and minlength

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,8 @@ fn test_filter() {
             threads: 1,
             contam: None,
             inverse: false,
-        },
+            input: None,
+	},
     );
 }
 
@@ -313,6 +314,7 @@ fn test_filter_with_contam() {
             threads: 1,
             contam: Some("test-data/random_contam.fa".to_owned()),
             inverse: false,
+	    input: None,
         },
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,11 +79,10 @@ fn main() {
 		Some(ref infile) => {
 			let path = Path::new(infile);
 			if path.extension().and_then(|s| s.to_str()) == Some("gz") {
-        		// deal with gz compressed file
+        			// deal with gz compressed file
 				let gzfile = File::open(&path).unwrap();
 				let mut decoder = GzDecoder::new(gzfile);
-
-    			filter(&mut decoder, args);
+    				filter(&mut decoder, args);
         	
 			}
 			else {


### PR DESCRIPTION
Hi @wdecoster 
I manage to modify the original code to implement the --input mentioned in issue [#10](https://github.com/wdecoster/chopper/issues/10). 
Breifly I just add an `--input` or `-i` to accept an input filename and transform to flow and input to `filter` function.
I also test it with
```bash
cat {FILEPATH}/test.fastq | ./chopper -q 10 > testQ10_old.fastq;
Kept 207 reads out of 250 reads

./chopper -q 10 -i {FILEPATH}/test.fastq > testQ10_new.fastq;
Kept 207 reads out of 250 reads
```
These run give the same result. I hope you like my modifications.