### PR TITLE
enhance -i performace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ clap = { version = "4.2.1", features = ["derive"] }
 rayon = "1.7.0"
 approx = "0.5.1"
 minimap2 = "0.1.17+minimap2.2.27"
-flate2 = "1.0"
+flate2 = { version = "1.0.17", features = ["zlib-ng"], default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use bio::io::fastq;
 use clap::Parser;
 use minimap2::*;
 use rayon::prelude::*;
-use std::io::{self, Read};
+use std::io::{self, Read, BufReader};
 use std::path::{PathBuf, Path};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -94,8 +94,9 @@ fn main() {
 			if path.extension().and_then(|s| s.to_str()) == Some("gz") {
         		// deal with gz compressed file
 				let gzfile = File::open(&path).expect("Error: Unable to open gzipped file");
-				let mut decoder = GzDecoder::new(gzfile);
-    				filter(&mut decoder, args);
+                let buf_reader = BufReader::with_capacity(512*1024, gzfile);
+				let mut decoder = GzDecoder::new(buf_reader);
+    			filter(&mut decoder, args);
         	
 			}
 			else {


### PR DESCRIPTION
Hi @wdecoster In the last version I submitted, a significant drop of performance using `-i` or `--input` for `.gz` file is observed. I did some modifications to the code to enhance the `--input` performace, breifly:
1. Use different version of `flate2` to achieve the best performance as mentioned in https://github.com/rust-lang/flate2-rs#Backends
2. Add a 512 k buf.
The performance is shown below:

| Data | File size | command | Version | Run time |
|:---:|:---:|:---:|:---:|:---:|
|DM.fastq.gz|21G| gunzip -c DM.fastq.gz \| ./chopper -q 10 -l 500 > test.fastq | Old version (0.8.0) | 658 s |
|DM.fastq.gz|21G| ./chopper -i DM.fastq.gz -q 10 -l 500 > test.fastq | Old version (0.8.0) | 3060 s |
|DM.fastq.gz|21G| ./chopper -i DM.fastq.gz -q 10 -l 500 > test.fastq | Current pull request version | 759 s |

Which is still worse than system-level gunzip, but close.