### PR TITLE
Add new trimming approach: Highest Quality Subread

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ Trimming Options:
           Possible values:
           - fixed-crop:      Remove a fixed number of bases from both ends of the read. Requires setting both --headcrop and --tailcrop
           - trim-by-quality: Trim low-quality bases from the ends of the read until reaching a base with quality ≥ --cutoff
-          - best-subread:    Extract the highest-quality subread based on --cutoff, trimming low-quality bases from both ends
+          - best-read-segment:    Extract the highest-quality read segment based on --cutoff, trimming low-quality bases from both ends
 
       --cutoff <CUTOFF>
-          Set the minimum quality score (Q-score) threshold for trimming low-quality bases from read ends. Required when using the `trim-by-quality` or `best-subread` trimming approaches
+          Set the minimum quality score (Q-score) threshold for trimming low-quality bases from read ends. Required when using the `trim-by-quality` or `best-read-segment` trimming approaches
 
       --headcrop <HEADCROP>
           Trim N bases from the start of each read. Required only when using the `fixed-crop` trimming approach

--- a/README.md
+++ b/README.md
@@ -56,16 +56,14 @@ Filtering Options:
 
       --maxlength <MAXLENGTH>
           Sets a maximum read length
-
-      --maxgc <MAXGC>
-          Filter max GC content
           
-          [default: 1]
+          [default: INF]
 
       --mingc <MINGC>
           Filter min GC content
-          
-          [default: 0]
+
+      --maxgc <MAXGC>
+          Filter max GC content
 
   -c, --contam <CONTAM>
           Filter contaminants against a fasta

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # chopper
 
 Rust implementation of [NanoFilt](https://github.com/wdecoster/nanofilt)+[NanoLyse](https://github.com/wdecoster/nanolyse), both originally written in Python. This tool, intended for long read sequencing such as PacBio or ONT, filters and trims a fastq file.  
-Filtering is done on average read quality and minimal or maximal read length, and applying a headcrop (start of read) and tailcrop (end of read) while printing the reads passing the filter.
+
+Filtering is based on average read quality, minimum or maximum read length, and GC content percentage.
+
+On the other hand, trimming is performed using one of three approaches:
+
+* Fixed cropping (head crop at the start of the read and tail crop at the end),
+
+* Quality-based trimming using a threshold,
+
+* Extracting the highest-quality sub-read based on a quality score.
+
+Reads that pass the filters are printed to standard output (STDOUT).
 
 Compared to the Python implementation the scope is to deliver the same results, almost the same functionality, at much faster execution times. At the moment this tool does not support filtering using a sequencing_summary file. If those features are of interest then please reach out.  
 
@@ -21,24 +32,80 @@ Reads on stdin and writes to stdout.
 Usage: chopper [OPTIONS]
 
 Options:
-  -q, --quality <MINQUAL>      Sets a minimum Phred average quality score [default: 0]
-      --maxqual <MAXQUAL>      Sets a maximum Phred average quality score [default: 1000]
-  -l, --minlength <MINLENGTH>  Sets a minimum read length [default: 1]
-      --maxlength <MAXLENGTH>  Sets a maximum read length
-      --headcrop <HEADCROP>    Trim N nucleotides from the start of a read [default: 0]
-      --tailcrop <TAILCROP>    Trim N nucleotides from the end of a read [default: 0]
-  -t, --threads <THREADS>      Use N parallel threads [default: 4]
-  -c, --contam <CONTAM>        Filter contaminants against a fasta
-      --inverse                Output the opposite of the normal results
-  -i, --input <INPUT>          Input filename [default: read from stdin]
-      --maxgc <MAXGC>          Filter max GC content [default: 1]
-      --mingc <MINGC>          Filter min GC content [default: 0]
-      --trim <TRIM>            Set a q-score cutoff to trim read ends
-  -h, --help                   Print help
-  -V, --version                Print version
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+Filtering Options:
+  -q, --quality <MINQUAL>
+          Sets a minimum Phred average quality score
+          
+          [default: 0]
+
+      --maxqual <MAXQUAL>
+          Sets a maximum Phred average quality score
+          
+          [default: 1000]
+
+  -l, --minlength <MINLENGTH>
+          Sets a minimum read length
+          
+          [default: 1]
+
+      --maxlength <MAXLENGTH>
+          Sets a maximum read length
+
+      --maxgc <MAXGC>
+          Filter max GC content
+          
+          [default: 1]
+
+      --mingc <MINGC>
+          Filter min GC content
+          
+          [default: 0]
+
+  -c, --contam <CONTAM>
+          Filter contaminants against a fasta
+
+Trimming Options:
+      --trim-approach <TRIM_APPROACH>
+          Select the trimming strategy to apply to the reads
+
+          Possible values:
+          - fixed-crop:      Remove a fixed number of bases from both ends of the read. Requires setting both --headcrop and --tailcrop
+          - trim-by-quality: Trim low-quality bases from the ends of the read until reaching a base with quality ≥ --cutoff
+          - best-subread:    Extract the highest-quality subread based on --cutoff, trimming low-quality bases from both ends
+
+      --cutoff <CUTOFF>
+          Set the minimum quality score (Q-score) threshold for trimming low-quality bases from read ends. Required when using the `trim-by-quality` or `best-subread` trimming approaches
+
+      --headcrop <HEADCROP>
+          Trim N bases from the start of each read. Required only when using the `fixed-crop` trimming approach
+          
+          [default: 0]
+
+      --tailcrop <TAILCROP>
+          Trim N bases from the end of each read. Required only when using the `fixed-crop` trimming approach
+          
+          [default: 0]
+
+Setup Options:
+  -t, --threads <THREADS>
+          Use N parallel threads
+          
+          [default: 4]
+
+  -i, --input <INPUT>
+          Input filename [default: read from stdin]
+
+      --inverse
+          Output the opposite of the normal results
 ```
 
-EXAMPLES:
+## Examples:
 
 ```bash
 gunzip -c reads.fastq.gz | chopper -q 10 -l 500 | gzip > filtered_reads.fastq.gz
@@ -46,6 +113,6 @@ chopper -q 10 -l 500 -i reads.fastq > filtered_reads.fastq
 chopper -q 10 -l 500 -i reads.fastq.gz | gzip > filtered_reads.fastq.gz
 ```
 
-## CITATION
+## Citation
 
 If you use this tool, please consider citing our [publication](https://academic.oup.com/bioinformatics/article/39/5/btad311/7160911).

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,64 +20,64 @@ mod utils;
 #[clap(author, version, about="Filtering and trimming of fastq files. Reads on stdin and writes to stdout.", long_about = None)]
 struct Cli {
     /// Sets a minimum Phred average quality score
-    #[arg(short = 'q', long = "quality", value_parser, default_value_t = 0.0)]
+    #[arg(short = 'q', long = "quality", value_parser, default_value_t = 0.0, help_heading = "Filtering Options")]
     minqual: f64,
 
     /// Sets a maximum Phred average quality score
-    #[arg(long, value_parser, default_value_t = 1000.0)]
+    #[arg(long, value_parser, default_value_t = 1000.0, help_heading = "Filtering Options")]
     maxqual: f64,
 
     /// Sets a minimum read length
-    #[arg(short = 'l', long, value_parser, default_value_t = 1)]
+    #[arg(short = 'l', long, value_parser, default_value_t = 1, help_heading = "Filtering Options")]
     minlength: usize,
 
     /// Sets a maximum read length
     // Default is largest i32. Better would be to explicitly use Inf, but couldn't figure it out.
-    #[arg(long, value_parser)]
+    #[arg(long, value_parser, help_heading = "Filtering Options")]
     maxlength: Option<usize>,
 
+    /// Filter max GC content
+    #[arg(long, value_parser, default_value_t = 1.0, help_heading = "Filtering Options")]
+    maxgc: f64,
+
+    /// Filter min GC content
+    #[arg(long, value_parser, default_value_t = 0.0, help_heading = "Filtering Options")]
+    mingc: f64,
+
+    /// Filter contaminants against a fasta
+    #[arg(short, long, value_parser, help_heading = "Filtering Options")]
+    contam: Option<String>,
+
     /// Select the trimming strategy to apply to the reads.
-    #[arg(long="trim-approach", value_parser)]
+    #[arg(long="trim-approach", value_parser, help_heading = "Trimming Options")]
     trim_approach: Option<TrimApproach>,
 
     /// Set the minimum quality score (Q-score) threshold for trimming low-quality bases from read ends.
     /// Required when using the `trim-by-quality` or `best-subread` trimming approaches.
-    #[arg(long, value_parser)]
+    #[arg(long, value_parser, help_heading = "Trimming Options")]
     cutoff: Option<u8>,
 
     /// Trim N bases from the start of each read.
     /// Required only when using the `fixed-crop` trimming approach.
-    #[arg(long, value_parser, default_value_t = 0)]
+    #[arg(long, value_parser, default_value_t = 0, help_heading = "Trimming Options")]
     headcrop: usize,
 
     /// Trim N bases from the end of each read.
     /// Required only when using the `fixed-crop` trimming approach.
-    #[arg(long, value_parser, default_value_t = 0)]
+    #[arg(long, value_parser, default_value_t = 0, help_heading = "Trimming Options")]
     tailcrop: usize,
 
     /// Use N parallel threads
-    #[arg(short, long, value_parser, default_value_t = 4)]
+    #[arg(short, long, value_parser, default_value_t = 4, help_heading = "Setup Options")]
     threads: usize,
 
-    /// Filter contaminants against a fasta
-    #[arg(short, long, value_parser)]
-    contam: Option<String>,
-
-    /// Output the opposite of the normal results
-    #[arg(long)]
-    inverse: bool,
-
     /// Input filename [default: read from stdin]
-    #[arg(short = 'i', long = "input", value_parser)]
+    #[arg(short = 'i', long = "input", value_parser, help_heading = "Setup Options")]
     input: Option<String>,
 
-    /// Filter max GC content
-    #[arg(long, value_parser, default_value_t = 1.0)]
-    maxgc: f64,
-
-    /// Filter min GC content
-    #[arg(long, value_parser, default_value_t = 0.0)]
-    mingc: f64,
+    /// Output the opposite of the normal results
+    #[arg(long, help_heading = "Setup Options")]
+    inverse: bool,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+mod trimmers;
 mod utils;
 use utils::file_reader;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,6 @@ struct Cli {
 
     /// Sets a maximum read length
     #[arg(long, value_parser = parse_usize_or_inf, default_value = "INF", help_heading = "Filtering Options")]
-    // #[arg(long, value_parser, default_value_t = usize::MAX, help_heading = "Filtering Options")]
     maxlength: usize,
 
     /// Filter min GC content

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,7 +276,7 @@ fn ave_qual(quals: &[u8]) -> f64 {
 /// ```
 /// let phred_score = 10; // Q10
 /// let expected = 0.1; // Error probability
-/// let actual phred_score_to_probability(phred_score);
+/// let actual = phred_score_to_probability(phred_score);
 /// assert_eq!(expected, actual);
 /// ```
 fn phred_score_to_probability(phred: u8) -> f64 {

--- a/src/trimmers.rs
+++ b/src/trimmers.rs
@@ -116,7 +116,7 @@ impl TrimStrategy for TrimByQualityStrategy {
     }
 }
 
-/// This strategy remove a fixed number of bases from both ends of the read.
+/// This strategy removes a fixed number of bases from both ends of the read.
 pub struct FixedCropStrategy {
     head_crop: usize,
     tail_crop: usize,

--- a/src/trimmers.rs
+++ b/src/trimmers.rs
@@ -130,7 +130,7 @@ impl FixedCropStrategy {
 
 impl TrimStrategy for FixedCropStrategy {
     fn trim(&self, record: &fastq::Record) -> Option<(usize, usize)> {
-        if record.seq().len() - self.tail_crop <= self.head_crop {
+        if record.seq().len().saturating_sub(self.tail_crop) <= self.head_crop {
             return None;
         }
         Some((self.head_crop, record.seq().len() - self.tail_crop))
@@ -225,9 +225,9 @@ mod tests {
     fn fixed_crop_strategy_test() {
         let cases: [(usize, usize, Option<(usize, usize)>); 6] = [
             (5, 3, Some((5, 17))),
-            (4, 4, Some((4, 16))),
+            (30, 4, None),
             (1, 1, Some((1, 19))),
-            (15, 15, None),
+            (15, 30, None),
             (19, 0, Some((19,20))),
             (0, 19, Some((0,1)))
         ];

--- a/src/trimmers.rs
+++ b/src/trimmers.rs
@@ -72,62 +72,170 @@ impl TrimStrategy for HighestQualityTrimStrategy {
     }
 }
 
+/// This strategy trims low-quality bases from both ends of the read 
+/// until it reaches a base with a quality score ≥ `cutoff` (Q-score).
+///
+/// Returns `Some((start, end))` with the indices of the valid subread 
+/// if one is found; otherwise, returns `None`.
+pub struct TrimByQualitytrategy {
+    cutoff: u8,
+}
+
+impl TrimByQualitytrategy {
+    pub fn new(cutoff: u8) -> TrimByQualitytrategy {
+        TrimByQualitytrategy { cutoff }
+    }
+}
+
+impl TrimStrategy for TrimByQualitytrategy {
+    fn trim(&self, record: &fastq::Record) -> Option<(usize, usize)> {
+        let read_len = record.seq().len();
+        let trim_threshold = self.cutoff;
+
+        // Quality-based trimming
+        let quals = record.qual();
+        
+        // Find first position from start with quality >= threshold
+        let mut trim_start = 0;
+        while trim_start < read_len && (quals[trim_start] - 33) < trim_threshold {
+            trim_start += 1;
+        }
+        
+        // Find first position from end with quality >= threshold
+        let mut trim_end = read_len;
+        while trim_end > trim_start && (quals[trim_end - 1] - 33) < trim_threshold {
+            trim_end -= 1;
+        }
+
+        if trim_end <= trim_start {
+            return None;
+        }
+        
+        Some((trim_start, trim_end))
+    }
+}
+
+/// This strategy remove a fixed number of bases from both ends of the read.
+pub struct FixedCropStrategy {
+    head_crop: usize,
+    tail_crop: usize,
+}
+
+impl FixedCropStrategy {
+    pub fn new(head_crop: usize, tail_crop: usize) -> FixedCropStrategy {
+        FixedCropStrategy { head_crop, tail_crop }
+    }
+}
+
+impl TrimStrategy for FixedCropStrategy {
+    fn trim(&self, record: &fastq::Record) -> Option<(usize, usize)> {
+        if record.seq().len() - self.tail_crop <= self.head_crop {
+            return None;
+        }
+        Some((self.head_crop, record.seq().len() - self.tail_crop))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bio::io::fastq;
     use super::*;
+
+    fn get_reads() -> [fastq::Record; 6] {
+        [
+            fastq::Record::with_attrs(
+                &"id-01",
+                None,
+                b"AAAAAAAAAAAAAAATTTAA",
+                b"&#3-G27C:(@G7B55+C4I"
+            ),
+            fastq::Record::with_attrs(
+                &"id-01",
+                None,
+                b"TTTTTTTTTTTTTTTTTTTT",
+                b"77%'24)FAF9@=94'%054"
+            ),
+            fastq::Record::with_attrs(
+                &"id-01",
+                None,
+                b"AAAAAAAAAAAAAAATTTTA",
+                b"'8$-BF2!C;+59->H@91#"
+            ),
+            fastq::Record::with_attrs(
+                &"id-01",
+                None,
+                b"AAAAAAAAAAAAAAAAAAAA",
+                b"%,42$CH*#0+0C6=0,*6/"
+            ),
+            fastq::Record::with_attrs(
+                &"id-01",
+                None,
+                b"AAAAAAAAAAAAAAAAAAAT",
+                b"-------------------J"
+            ),
+            fastq::Record::with_attrs(
+                &"id-01",
+                None,
+                b"TAAAAAAAAAAAAAAAAAAA",
+                b"I-------------------"
+            ),
+        ]
+    }
     
     #[test]
     fn highest_quality_sub_read_test() {
-        let cases: [(fastq::Record, f64, Option<(usize, usize)>); 6] = [
-            (
-                fastq::Record::with_attrs(
-                    &"id-01",
-                    None,
-                    b"AAAAAAAAAAAAAAATTTAA",
-                    b"&#3-G27C:(@G7B55+C4I"
-                ), 0.01, Some((10, 16)), // cutoff: Q20
-            ), ( // TODO: calcular
-                fastq::Record::with_attrs(
-                    &"id-01",
-                    None,
-                    b"TTTTTTTTTTTTTTTTTTTT",
-                    b"77%'24)FAF9@=94'%054"
-                ), 0.19952623149688797, Some((0, 20)), // cutoff: Q7
-            ), (
-                fastq::Record::with_attrs(
-                    &"id-01",
-                    None,
-                    b"AAAAAAAAAAAAAAATTTTA",
-                    b"'8$-BF2!C;+59->H@91#"
-                ), 0.03162277660168379, Some((11, 19)), // cutoff: Q15
-            ), (
-                fastq::Record::with_attrs(
-                    &"id-01",
-                    None,
-                    b"AAAAAAAAAAAAAAAAAAAA",
-                    b"%,42$CH*#0+0C6=0,*6/"
-                ), 0.0001, None, // cutoff: Q40
-            ), (
-                fastq::Record::with_attrs(
-                    &"id-01",
-                    None,
-                    b"AAAAAAAAAAAAAAAAAAAT",
-                    b"-------------------J"
-                ), 0.0001, Some((19,20)), // cutoff: Q40
-            ), (
-                fastq::Record::with_attrs(
-                    &"id-01",
-                    None,
-                    b"TAAAAAAAAAAAAAAAAAAA",
-                    b"I-------------------"
-                ), 0.0001, Some((0,1)), // cutoff: Q40
-            )
+        let cases: [(f64, Option<(usize, usize)>); 6] = [
+            (0.01, Some((10, 16))), // cutoff: Q20)
+            (0.19952623149688797, Some((0, 20))), // cutoff: Q7
+            (0.03162277660168379, Some((11, 19))), // cutoff: Q15
+            (0.0001, None), // cutoff: Q40
+            (0.0001, Some((19,20))), // cutoff: Q40
+            (0.0001, Some((0,1)))  // cutoff: Q40
         ];
 
-        for (read, cutoff, expected) in cases {
-            let trim_strategy = HighestQualityTrimStrategy::new(cutoff);
-            assert_eq!(trim_strategy.trim(&read) , expected);
+        let reads = get_reads();
+
+        for ((cutoff, expected), read) in cases.iter().zip(reads) {
+            let trim_strategy = HighestQualityTrimStrategy::new(*cutoff);
+            assert_eq!(trim_strategy.trim(&read) , *expected);
+        }
+    }
+
+    #[test]
+    fn trim_by_quality_strategy_test() {
+        let cases: [(u8, Option<(usize, usize)>); 6] = [
+            ( 20, Some((4, 20))),
+            ( 7, Some((0, 20))),
+            (15, Some((1, 19))),
+            (40, None),
+            (40, Some((19,20))),
+            (40, Some((0,1)))
+        ];
+
+        let reads = get_reads();
+
+        for ((cutoff, expected), read) in cases.iter().zip(reads) {
+            let trim_strategy = TrimByQualitytrategy::new(*cutoff);
+            assert_eq!(trim_strategy.trim(&read) , *expected);
+        }
+    }
+
+    #[test]
+    fn fixed_crop_strategy_test() {
+        let cases: [(usize, usize, Option<(usize, usize)>); 6] = [
+            (5, 3, Some((5, 17))),
+            (4, 4, Some((4, 16))),
+            (1, 1, Some((1, 19))),
+            (15, 15, None),
+            (19, 0, Some((19,20))),
+            (0, 19, Some((0,1)))
+        ];
+
+        let reads = get_reads();
+
+        for ((head_crop, tail_crop, expected), read) in cases.iter().zip(reads) {
+            let trim_strategy = FixedCropStrategy::new(*head_crop, *tail_crop);
+            assert_eq!(trim_strategy.trim(&read) , *expected);
         }
     }
 }

--- a/src/trimmers.rs
+++ b/src/trimmers.rs
@@ -46,7 +46,9 @@ impl TrimStrategy for HighestQualityTrimStrategy {
         let mut current_start = 0;
         let mut current_cumulative_error = -1.0;
         for (i, phred_qual) in record.qual().iter().enumerate() {
-            let prob_error = self.cutoff - phred_score_to_probability(*phred_qual);
+            // The FASTQ Phred quality score must be converted from its ASCII representation
+            // before calling phred_score_to_probability
+            let prob_error = self.cutoff - phred_score_to_probability(*phred_qual - 33);
             if current_cumulative_error < 0.0 {
                 current_cumulative_error = 0.0;
                 current_start = i;

--- a/src/trimmers.rs
+++ b/src/trimmers.rs
@@ -9,7 +9,7 @@ use super::phred_score_to_probability;
 ///
 /// The `trim` method should return `Some((start, end))` if a valid sub-read  
 /// is identified, or `None` if the read should be discarded.
-pub trait TrimStrategy {
+pub trait TrimStrategy: Send + Sync {
     /// Performs the trimming process based on the defined strategy.
     ///
     /// Returns `Some((start, end))` with the indices of the trimmed region  

--- a/src/trimmers.rs
+++ b/src/trimmers.rs
@@ -43,7 +43,6 @@ impl TrimStrategy for HighestQualityTrimStrategy {
         let mut best_length = 0;
 
         let mut current_start = 0;
-        let mut current_end;
         let mut current_cumulative_error = -1.0;
         for (i, phred_qual) in record.qual().iter().enumerate() {
             let prob_error = self.cutoff - phred_score_to_probability(*phred_qual);
@@ -53,14 +52,13 @@ impl TrimStrategy for HighestQualityTrimStrategy {
             } 
 
             current_cumulative_error += prob_error;
-            current_end = i;
             
             if best_cumulative_error < current_cumulative_error ||
-                (best_cumulative_error == current_cumulative_error && best_length < current_end - current_start + 1) {
+                (best_cumulative_error == current_cumulative_error && best_length < i - current_start + 1) {
                 best_start = current_start;
-                best_end = current_end;
+                best_end = i;
                 best_cumulative_error = current_cumulative_error;
-                best_length = current_end - current_start + 1;
+                best_length = i - current_start + 1;
             }
         }
 

--- a/src/trimmers.rs
+++ b/src/trimmers.rs
@@ -1,0 +1,133 @@
+use bio::io::fastq;
+use super::phred_score_to_probability;
+
+/// A trait for implementing custom read trimming strategies.
+///
+/// Implementing this trait allows you to define how a read should be trimmed  
+/// according to a specific algorithm or criteria. This is useful when working  
+/// with different trimming approaches.
+///
+/// The `trim` method should return `Some((start, end))` if a valid sub-read  
+/// is identified, or `None` if the read should be discarded.
+pub trait TrimStrategy {
+    /// Performs the trimming process based on the defined strategy.
+    ///
+    /// Returns `Some((start, end))` with the indices of the trimmed region  
+    /// if a valid sub-read is identified, or `None` if the read should be discarded.
+    fn trim(&self, record: &fastq::Record) -> Option<(usize, usize)>;
+}
+
+/// A trimming strategy that applies a modified Mott algorithm to extract the highest-quality sub-read.
+///
+/// This strategy identifies the sub-read with the lowest cumulative error probability,
+/// following an approach similar to Phred quality trimming. It is useful for removing
+/// low-quality bases typically found at the ends of reads.
+///
+/// When used, it returns `Some((start, end))` with the indices of the highest-quality
+/// sub-read if one is found; otherwise, returns None.
+pub struct HighestQualityTrimStrategy {
+    cutoff: f64,
+}
+
+impl HighestQualityTrimStrategy {
+    pub fn new(cutoff: f64) -> HighestQualityTrimStrategy  {
+        HighestQualityTrimStrategy { cutoff }
+    }
+}
+
+impl TrimStrategy for HighestQualityTrimStrategy {
+    fn trim(&self, record: &fastq::Record) -> Option<(usize, usize)> {
+        let mut best_start = usize::MAX;
+        let mut best_end = usize::MAX;
+        let mut best_cumulative_error = 0.0;
+        let mut best_length = 0;
+
+        let mut current_start = 0;
+        let mut current_end;
+        let mut current_cumulative_error = -1.0;
+        for (i, phred_qual) in record.qual().iter().enumerate() {
+            let prob_error = self.cutoff - phred_score_to_probability(*phred_qual);
+            if current_cumulative_error < 0.0 {
+                current_cumulative_error = 0.0;
+                current_start = i;
+            } 
+
+            current_cumulative_error += prob_error;
+            current_end = i;
+            
+            if best_cumulative_error < current_cumulative_error ||
+                (best_cumulative_error == current_cumulative_error && best_length < current_end - current_start + 1) {
+                best_start = current_start;
+                best_end = current_end;
+                best_cumulative_error = current_cumulative_error;
+                best_length = current_end - current_start + 1;
+            }
+        }
+
+        if best_start == usize::MAX {
+            None
+        } else {
+            Some((best_start, best_end+1))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bio::io::fastq;
+    use super::*;
+    
+    #[test]
+    fn highest_quality_sub_read_test() {
+        let cases: [(fastq::Record, f64, Option<(usize, usize)>); 6] = [
+            (
+                fastq::Record::with_attrs(
+                    &"id-01",
+                    None,
+                    b"AAAAAAAAAAAAAAATTTAA",
+                    b"&#3-G27C:(@G7B55+C4I"
+                ), 0.01, Some((10, 16)), // cutoff: Q20
+            ), ( // TODO: calcular
+                fastq::Record::with_attrs(
+                    &"id-01",
+                    None,
+                    b"TTTTTTTTTTTTTTTTTTTT",
+                    b"77%'24)FAF9@=94'%054"
+                ), 0.19952623149688797, Some((0, 20)), // cutoff: Q7
+            ), (
+                fastq::Record::with_attrs(
+                    &"id-01",
+                    None,
+                    b"AAAAAAAAAAAAAAATTTTA",
+                    b"'8$-BF2!C;+59->H@91#"
+                ), 0.03162277660168379, Some((11, 19)), // cutoff: Q15
+            ), (
+                fastq::Record::with_attrs(
+                    &"id-01",
+                    None,
+                    b"AAAAAAAAAAAAAAAAAAAA",
+                    b"%,42$CH*#0+0C6=0,*6/"
+                ), 0.0001, None, // cutoff: Q40
+            ), (
+                fastq::Record::with_attrs(
+                    &"id-01",
+                    None,
+                    b"AAAAAAAAAAAAAAAAAAAT",
+                    b"-------------------J"
+                ), 0.0001, Some((19,20)), // cutoff: Q40
+            ), (
+                fastq::Record::with_attrs(
+                    &"id-01",
+                    None,
+                    b"TAAAAAAAAAAAAAAAAAAA",
+                    b"I-------------------"
+                ), 0.0001, Some((0,1)), // cutoff: Q40
+            )
+        ];
+
+        for (read, cutoff, expected) in cases {
+            let trim_strategy = HighestQualityTrimStrategy::new(cutoff);
+            assert_eq!(trim_strategy.trim(&read) , expected);
+        }
+    }
+}


### PR DESCRIPTION
Hi @wdecoster,
I've used Chopper a couple of times and found it to be a very useful and easy-to-use trimming tool. I wanted to contribute my small grain of sand. I apologize, as I initially started with a simple idea, but along the way I ended up making additional changes, which might make it a bit harder to review everything in detail. Here’s a brief overview of my contribution:

## What's new?

A new trimming strategy called **Highest Quality Subread** was added. It is based on the algorithm presented by [Phred](http://www.phrap.org/phredphrap/phred.html), which identifies the highest-quality subread based on a cutoff value (`--cutoff`).

## How does the algorithm work?

The behavior of this new trimming approach can be summarized in four steps:

1. For each base in the read, the Phred quality score is converted into an error probability.
2. For each base, a score is calculated as the difference between the `--cutoff` value and the error probability; bases with a negative score are considered to have insufficient quality.
3. The subsequence with the highest cumulative score is identified using Kadane’s algorithm.
4. The indices of the highest-quality subread are returned, if one is found.

## Types of changes

### New feature

- A new trimming approach was implemented, and the `TrimStrategy` trait was created to standardize the logic across different strategies, making the system easier to extend and maintain.
- The `--trim-approach` flag was added to allow users to select one of the available trimming strategies, while ensuring only one strategy is applied at a time.
- The `--cutoff` flag was added to define a quality threshold for strategies that require it (e.g., `trim-by-quality` and `best-subread`).

### Additional implementations

- `parse_gc_value` function was added to parse GC content parameters and validate that their values fall within the `[0, 1]` range.
- `parse_usize_or_inf` function was added to parse the maximum read length, allowing the terminal to display `INF` (instead of `usize::MAX`) as default value.
- The `build_trimming_approach` function was added to construct the appropriate trimming strategy and validate that all required parameters (`--cutoff`, `--headcrop`, `--tailcrop`) have been provided for the selected strategy.

### Refactoring

- The `--trim` flag was removed and replaced by `--cutoff`, which must now be used together with the `--trim-approach trim-by-quality` flag.
- The new `--trim-approach` flag allows selecting one of three strategies: fixed-length trimming (`fixed-crop`), quality-based trimming (`trim-by-quality`), and best subread extraction (`best-subread`).
- CLI argument presentation was reorganized and grouped into three categories in the help output: **Filtering options**, **Trimming options**, and **Setup options**.
- Trimming logic was extracted from the `write_record` function and encapsulated into dedicated structs implementing the `TrimStrategy` trait.
- The `write_record` function was simplified to focus solely on writing reads to output.
- The `filter` function was refactored to improve readability and modularity.
- All tests using the `Cli` structure were updated accordingly.

### Bugfix

- Validation for `--gcmin` and `--gcmax` was added to the `filter` function when the `--inverse` flag is used.

## Testing

- All existing tests were verified and passed successfully.
- The tool was tested on a Linux system (Debian 12) and compared against version `0.10.0` installed via Conda.
- Multiple FASTQ files were used to confirm consistent results. Identical output was observed in all cases, except when using the `--inverse` flag with `--gcmin` and/or `--gcmax`, where the new logic now takes GC limits into account when `--inverse` flag is set.

## Benchmark

To evaluate performance, `chopper v0.10.0` (installed via Conda) was compared with the new version using a 8.9 GB FASTQ file. The following parameters were used:

```bash
# Old version
chopper -t <THREADS> --trim 25 --mingc 0.2 --maxgc 0.8 -q 25 -i <TEST_FILE>

# New version
<PATH_TO_CHOPPER_RELEASE> -t <THREADS> --trim-approach trim-by-quality --cutoff 25 --mingc 0.2 --maxgc 0.8 -q 25 -i <TEST_FILE>
```

Each version was executed 20 times using 1 and 4 threads, and the average execution time (in seconds) was recorded. The table below shows similar performance between both versions, with the new version being slightly faster on average.

| Version             | Avg time (1 thread) | Avg time (4 threads) |
|---------------------|---------------------|----------------------|
| chopper_v0.10.0     | 95.1797 s           | 39.2535 s            |
| chopper_new_version | 93.4072 s           | 39.2436 s            |